### PR TITLE
Displaying FileExplorer By Importing Folder/File with dialog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11813,6 +11813,11 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
+    "vuex": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
+      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
+    },
     "watchpack": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",

--- a/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
@@ -5,6 +5,7 @@
        :key="index"
        :fileName="file.fileName"
        :files="file.files"
+       :filePath="file.filePath"
        :depth="0"
        >
     </FileFolderItem>

--- a/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
@@ -1,6 +1,12 @@
 <template>
   <div v-if="$store.getters.getFileTree" class="fileExplorer-container">
-    <FileFolderItem v-for="(file, index) in $store.getters.getFileTree" :key="index" :fileName="file.fileName" :files="file.files">
+    <FileFolderItem
+       v-for="(file, index) in $store.getters.getFileTree"
+       :key="index"
+       :fileName="file.fileName"
+       :files="file.files"
+       :depth="0"
+       >
     </FileFolderItem>
   </div>
 </template>

--- a/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
@@ -1,13 +1,37 @@
 <template>
-  <div class="fileExplorer-container">
-      <p>Im inside FileExplorer</p>
+  <div v-if="$store.getters.getFileTree" class="fileExplorer-container" v-html="generateFileTreeHtml(this.$store.getters.getFileTree)">
+
   </div>
 </template>
 
 <script>
-  export default {
 
+  export default {
+    methods: {
+      generateFileTreeHtml(fileTreeArray) {
+        let fileTreeStr = '';
+        
+        function traverseFileTree(fileTree) {
+          fileTreeStr += `<ul><li>${fileTree.fileName}</li>`;
+          for(let i = 0; i < fileTree.files.length; i++) {
+            traverseFileTree(fileTree.files[i]);
+          }
+          fileTreeStr += `</ul>`;
+        };
+
+
+        for(let i = 0; i < fileTreeArray.length; i++) {
+          if (fileTreeArray[i]) {
+            traverseFileTree(fileTreeArray[i]);
+          }
+        }
+        
+        return fileTreeStr;
+      }
+    }
   }
+    // template: `<div class="fileExplorer-container">${generateFileTreeHtml(this.$store.getters.getFileTree)}</div>`
+  
 </script>
 
 <style> 
@@ -15,5 +39,6 @@
     border: 1px red solid;
     width: 25%;
     height: 100%;
+    overflow: scroll;
   }
 </style>

--- a/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
@@ -1,46 +1,18 @@
 <template>
-  <div v-if="$store.getters.getFileTree" class="fileExplorer-container" v-html="generateFileTreeHtml(this.$store.getters.getFileTree)">
-
+  <div v-if="$store.getters.getFileTree" class="fileExplorer-container">
+    <FileFolderItem v-for="(file, index) in $store.getters.getFileTree" :key="index" :fileName="file.fileName" :files="file.files">
+    </FileFolderItem>
   </div>
 </template>
 
 <script>
-
+  import FileFolderItem from './FileFolderItem.vue';
   export default {
-    methods: {
-      generateFileTreeHtml(fileTreeArray) {
-        let fileTreeStr = '';
-        
-        function traverseFileTree(fileTree) {
-          if(fileTree.files.length > 0) {
-            fileTreeStr += `<ul><li><button @click="toggleShowSubfolder">${fileTree.fileName}</button></li>`;
-            for(let i = 0; i < fileTree.files.length; i++) {
-              traverseFileTree(fileTree.files[i]);
-            }
-          } else {
-            fileTreeStr += `<ul><li><button @dblclick="displayCode">${fileTree.fileName}</button></li>`;
-          }
-          fileTreeStr += `</ul>`;
-        };
-
-
-        for(let i = 0; i < fileTreeArray.length; i++) {
-          if (fileTreeArray[i]) {
-            traverseFileTree(fileTreeArray[i]);
-          }
-        }
-        
-        return fileTreeStr;
-      }
-    }, 
-    toggleShowSubFolder() {
-      console.log('toggling folders.....')
-    },
-    displayCode() {
-      console.log('displaying your code........')
+    name: 'fileExplorer',
+    components: {
+      FileFolderItem,
     }
   }
-    // template: `<div class="fileExplorer-container">${generateFileTreeHtml(this.$store.getters.getFileTree)}</div>`
   
 </script>
 

--- a/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileExplorer.Vue
@@ -12,9 +12,13 @@
         let fileTreeStr = '';
         
         function traverseFileTree(fileTree) {
-          fileTreeStr += `<ul><li>${fileTree.fileName}</li>`;
-          for(let i = 0; i < fileTree.files.length; i++) {
-            traverseFileTree(fileTree.files[i]);
+          if(fileTree.files.length > 0) {
+            fileTreeStr += `<ul><li><button @click="toggleShowSubfolder">${fileTree.fileName}</button></li>`;
+            for(let i = 0; i < fileTree.files.length; i++) {
+              traverseFileTree(fileTree.files[i]);
+            }
+          } else {
+            fileTreeStr += `<ul><li><button @dblclick="displayCode">${fileTree.fileName}</button></li>`;
           }
           fileTreeStr += `</ul>`;
         };
@@ -28,6 +32,12 @@
         
         return fileTreeStr;
       }
+    }, 
+    toggleShowSubFolder() {
+      console.log('toggling folders.....')
+    },
+    displayCode() {
+      console.log('displaying your code........')
     }
   }
     // template: `<div class="fileExplorer-container">${generateFileTreeHtml(this.$store.getters.getFileTree)}</div>`

--- a/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
@@ -1,7 +1,13 @@
 <template>
   <ul>
-    <li>{{ fileName }}</li>
-    <file-folder v-for="(file, index) in files" :key="index" :fileName="file.fileName" :files="file.files">
+    <li :style="indent">{{ fileName }}</li>
+    <file-folder
+       v-for="(file, index) in files"
+       :key="index" 
+       :fileName="file.fileName"
+       :files="file.files"
+       :depth="depth + 1" 
+        >
 
     </file-folder>
   </ul>
@@ -10,6 +16,17 @@
 <script>
 export default {
   name: 'file-folder',
-  props: ['fileName', 'files'],
+  props: ['fileName', 'files', 'depth'],
+  computed: {
+    indent() {
+      return { 
+        transform: `translate(${this.depth * 50}px)`,
+        "list-style": `none`
+        }
+    }
+  }
 }
 </script>
+
+
+

--- a/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
@@ -2,8 +2,8 @@
   <ul v-if="files.length > 0">
     <li :style="indent" @click="toggleChildren">{{ fileName }}</li>
     <file-folder
-       v-if="showChildren"
        v-for="(file, index) in files"
+       v-if="showChildren"
        :key="index" 
        :fileName="file.fileName"
        :files="file.files"
@@ -12,14 +12,14 @@
     </file-folder>
   </ul>
   <ul v-else>
-    <li :style="indent" @dblclick="displayFileContent">{{ fileName }}</li>
+    <li :style="indent" @dblclick="displayFileContent(filePath)">{{ fileName }}</li>
   </ul>
 </template>
 
 <script>
 export default {
   name: 'file-folder',
-  props: ['fileName', 'files', 'depth'],
+  props: ['fileName', 'files', 'depth', 'filePath'],
   data() {
     return {
       showChildren: false
@@ -37,8 +37,10 @@ export default {
     toggleChildren() {
       this.showChildren = !this.showChildren;
     },
-    displayFileContent() {
-      console.log('diplaying your contents!!!!!!')
+    displayFileContent(filePath) {
+      // IMPLEMENT FUNCTIONALITY FOR DISPLAYING FILE CONTENT
+      
+      console.log('diplaying your contents!!!!!!', filePath)
     }
   }
 }

--- a/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
@@ -8,6 +8,7 @@
        :fileName="file.fileName"
        :files="file.files"
        :depth="depth + 1" 
+       :filePath="file.filePath"
         >
     </file-folder>
   </ul>

--- a/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
@@ -1,15 +1,18 @@
 <template>
-  <ul>
-    <li :style="indent">{{ fileName }}</li>
+  <ul v-if="files.length > 0">
+    <li :style="indent" @click="toggleChildren">{{ fileName }}</li>
     <file-folder
+       v-if="showChildren"
        v-for="(file, index) in files"
        :key="index" 
        :fileName="file.fileName"
        :files="file.files"
        :depth="depth + 1" 
         >
-
     </file-folder>
+  </ul>
+  <ul v-else>
+    <li :style="indent" @dblclick="displayFileContent">{{ fileName }}</li>
   </ul>
 </template>
 
@@ -17,12 +20,25 @@
 export default {
   name: 'file-folder',
   props: ['fileName', 'files', 'depth'],
+  data() {
+    return {
+      showChildren: false
+    }
+  },
   computed: {
     indent() {
       return { 
-        transform: `translate(${this.depth * 50}px)`,
+        transform: `translate(${this.depth * 20}px)`,
         "list-style": `none`
         }
+    }
+  },
+  methods: {
+    toggleChildren() {
+      this.showChildren = !this.showChildren;
+    },
+    displayFileContent() {
+      console.log('diplaying your contents!!!!!!')
     }
   }
 }

--- a/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
+++ b/src/renderer/containers/MainLoader/FileExplorer/FileFolderItem.vue
@@ -1,0 +1,15 @@
+<template>
+  <ul>
+    <li>{{ fileName }}</li>
+    <file-folder v-for="(file, index) in files" :key="index" :fileName="file.fileName" :files="file.files">
+
+    </file-folder>
+  </ul>
+</template>
+
+<script>
+export default {
+  name: 'file-folder',
+  props: ['fileName', 'files'],
+}
+</script>

--- a/src/renderer/containers/MainLoader/Header/components/LeftHeader.Vue
+++ b/src/renderer/containers/MainLoader/Header/components/LeftHeader.Vue
@@ -10,24 +10,93 @@ const { remote } = window.require('electron');
 const electronFs = remote.require('fs');
 const { dialog } = remote
 
- const handleOpenFolder = () => {
+ function handleOpenFolder(){
     const directory = dialog.showOpenDialog({
       properties: ['openDirectory'],
       filters: [
-        { name: 'Javascript Files', extensions: ['js', 'jsx'] },
+        { name: 'Javascript Files', extensions: ['js'] },
+        { name: 'Vue Files', extensions: ['vue']},
         { name: 'Style', extensions: ['css'] },
         { name: 'Html', extensions: ['html'] },
       ],
     });
-    return directory
+    
+    if (directory && directory[0]) {
+      const directoryPath = directory[0];
+      this.$store.dispatch(setFilePath(directoryPath));
+      this.$store.dispatch(createFileTree({}))
+    }
+
+    console.log(this.$store.getters.getFilePath, '<--- Path')
+    console.log(this.$store.getters.getFileTree, '<--- Tree')
+
+ }
+
+  //  console.log(electronFs.readdirSync(directoryPath));
+ function generateFileTreeObject(directoryPath){
+
+    //input path (string)
+    //output array of objects. Each object will have filepath, filename, and files (if folder)
+    //fileObject = (keys for the object: filepath, filename, files(array))
+
+
+    //create an array(fileArray) to store fileObjects
+    const fileArray = electronFs.readdirSync(directoryPath).map(fileName => {
+      //For each file in the input directory path, get fileName, get current file's filepath and create files (array)
+      const file = {
+        fileName,
+        filePath: `${directoryPath}/${fileName}`,
+        files: []
+      }
+    //get the stats/data of current file
+    const fileStats = electronFs.statSync(file.filePath)
+    //check if its a directory , .git, node_modules
+    if (fileName !== '.git' && fileName !== 'node_modules') {
+      //if directory 
+      if (fileStats.isDirectory()) {
+        //make recursive call with current fileObject.filePath and save to fileObject.files
+        file.files = generateFileTreeObject(file.filePath)
+      }
+    //return fileObject
+      return file;
+    }
+    })
+
+return fileArray
+
+
+
+    //output will be fileArray(will contain fileObjects)
  }
 
 
 export default {
-  name: "leftHeader",
+  name: "leftHeader", 
   methods: {
     openProject() {
-     console.log(handleOpenFolder())
+    //  console.log(handleOpenFolder())
+     const directory = dialog.showOpenDialog({
+      properties: ['openDirectory'],
+      filters: [
+        { name: 'Javascript Files', extensions: ['js'] },
+        { name: 'Vue Files', extensions: ['vue']},
+        { name: 'Style', extensions: ['css'] },
+        { name: 'Html', extensions: ['html'] },
+      ],
+    });
+    
+    if (directory && directory[0]) {
+      const directoryPath = directory[0];
+      const testObj = {'/User/me': 'hellooo'}
+      this.$store.dispatch('setFilePath', directoryPath);
+      this.$store.dispatch('createFileTree', testObj)
+    }
+    const filePath2 = this.$store.getters.getFilePath;
+    const test = generateFileTreeObject(filePath2);
+    console.log(test)
+      // console.log(this.$store.getters.getFilePath, '<--- Path')
+      // const test = this.$store.getters.getFileTree['/User/me']
+      // console.log(test , '<--- test')
     }
   }
 }

--- a/src/renderer/containers/MainLoader/Header/components/LeftHeader.Vue
+++ b/src/renderer/containers/MainLoader/Header/components/LeftHeader.Vue
@@ -57,9 +57,9 @@ const { dialog } = remote
         //make recursive call with current fileObject.filePath and save to fileObject.files
         file.files = generateFileTreeObject(file.filePath)
       }
-    //return fileObject
+      //return fileObject
       return file;
-    }
+     }
     })
 
 return fileArray
@@ -89,11 +89,12 @@ export default {
       const directoryPath = directory[0];
       const testObj = {'/User/me': 'hellooo'}
       this.$store.dispatch('setFilePath', directoryPath);
-      this.$store.dispatch('createFileTree', testObj)
+      this.$store.dispatch('createFileTree', generateFileTreeObject(directoryPath));
     }
-    const filePath2 = this.$store.getters.getFilePath;
-    const test = generateFileTreeObject(filePath2);
-    console.log(test)
+    // const filePath2 = this.$store.getters.getFilePath;
+    // const test = generateFileTreeObject(filePath2);
+    // console.log(test)
+    console.log(this.$store.getters.getFileTree, '<---- fileTree')
       // console.log(this.$store.getters.getFilePath, '<--- Path')
       // const test = this.$store.getters.getFileTree['/User/me']
       // console.log(test , '<--- test')

--- a/src/renderer/containers/MainLoader/Header/components/LeftHeader.Vue
+++ b/src/renderer/containers/MainLoader/Header/components/LeftHeader.Vue
@@ -58,11 +58,11 @@ const { dialog } = remote
         file.files = generateFileTreeObject(file.filePath)
       }
       //return fileObject
-      return file;
+        return file;
      }
     })
 
-return fileArray
+return fileArray.filter(file => typeof file === 'object')
 
 
 

--- a/src/renderer/containers/MainLoader/Header/components/LeftHeader.Vue
+++ b/src/renderer/containers/MainLoader/Header/components/LeftHeader.Vue
@@ -1,13 +1,35 @@
 <template>
   <div class="left-header">
     <button class="button fileExplorerButton" @click="$store.dispatch('toggleFileExplorer')">File Explorer</button>
-    <button class="button openProjectButton">Open Project</button>
+    <button class="button openProjectButton" @click="openProject">Open Project</button>
   </div>
 </template>
 
 <script>
+const { remote } = window.require('electron');
+const electronFs = remote.require('fs');
+const { dialog } = remote
+
+ const handleOpenFolder = () => {
+    const directory = dialog.showOpenDialog({
+      properties: ['openDirectory'],
+      filters: [
+        { name: 'Javascript Files', extensions: ['js', 'jsx'] },
+        { name: 'Style', extensions: ['css'] },
+        { name: 'Html', extensions: ['html'] },
+      ],
+    });
+    return directory
+ }
+
+
 export default {
-  
+  name: "leftHeader",
+  methods: {
+    openProject() {
+     console.log(handleOpenFolder())
+    }
+  }
 }
 </script>
 

--- a/src/renderer/containers/MainLoader/MainLoader.vue
+++ b/src/renderer/containers/MainLoader/MainLoader.vue
@@ -32,13 +32,11 @@
 
 <style>
   .mainLoader-container {
-    height: 100%;
-    border: 1px red solid;
-    
+    height: 92%;
   }
 
   .mainLoader-container-f {
-    height: 100%;
+    height: 92%;
   }
 
   .mainLoader {

--- a/src/renderer/store/store.js
+++ b/src/renderer/store/store.js
@@ -6,18 +6,34 @@ Vue.use(Vuex);
 export const store = new Vuex.Store({
   state: {
     showFileExplorer: true,
+    fileTree: null,
+    filePath: null
   },
   mutations: {
     changeFileExplorer(state) {
       state.showFileExplorer = !state.showFileExplorer;
     },
+    updateFilePath(state, payload) {
+      state.filePath = payload.path;
+    }, 
+    updateFileTree(state, payload) {
+      state.fileTree = payload.fileTree;
+    }, 
   }, 
   actions: {
     toggleFileExplorer(context) {
       context.commit('changeFileExplorer');
     },
+    setFilePath(context, path) {
+      context.commit('updateFilePath', { path })
+    },
+    createFileTree(context, fileTree) {
+      context.commit('updateFileTree', { fileTree })
+    }
   },
   getters: {
     showFileExplorer: state => state.showFileExplorer,
+    getFileTree: state => state.fileTree,
+    getFilePath: state => state.filePath,
   }
 })


### PR DESCRIPTION
1. Created functionality to allow users to select a desired folder by using electron's openDialog.
2. Stored the contents of the selected folder into an object called fileTree and saved it to the store.
3. Added functionality to display each individual item in fileTree object. 
4. Added doubleClick functionality to all files and folder to console.log their file path. (Will use file path to render the contents of the file with Monaco Editor in the future)
5.Added @click functionality to show/hide contents of a folder in FileTree Explorer.
6. Added style to fileExplorer to indent based off depth in fileTree object